### PR TITLE
Processa eventos START/STOP/EMERGENCY vindos do MCU

### DIFF
--- a/config.py
+++ b/config.py
@@ -33,7 +33,7 @@ class Config:
     MQTT_PUBLISHER_PORT = DEFAULT_MQTT_BROKER_PORT
 
     UART_COMMAND_ENCODINGS = {
-        ("control_cbelt", "START"): "00100000",
+        ("control_cbelt", "START"): "10000000",
         ("control_cbelt", "STOP"):  "00100000",
         ("control_cbelt", "EMERGENCY"): "01000000",
         ("control_cbelt", "RESET"):     "01010000",

--- a/config.py
+++ b/config.py
@@ -29,6 +29,7 @@ class Config:
     MQTT_TOPIC_METRICS = "embrapac/edge/aggregated-metrics"
     MQTT_TOPIC_DATA_DETECTIONS = "embrapac/edge/count"
     MQTT_TOPIC_CBELT_STATUS = "embrapac/edge/cbelt"
+    MQTT_TOPIC_CBELT_ACTUATOR = "embrapac/edge/cbelt/status"
     MQTT_PUBLISHER_HOST = DEFAULT_GENERAL_SERVER_IP
     MQTT_PUBLISHER_PORT = DEFAULT_MQTT_BROKER_PORT
 

--- a/data_aggregator/uart_subscriber.py
+++ b/data_aggregator/uart_subscriber.py
@@ -67,22 +67,22 @@ class UARTSubscriber:
         detected_class = None
         state = 'NORMAL'
         status = None
-        if payload == '10000000':
+        if payload == b'\x80':  # 10000000
             logger.warn('Received UART payload: no detections, system online')
             status = 'START'
-        elif payload == '10000001':
+        elif payload == b'\x81':  # 10000001
             logger.info('Received UART payload: detected P')
             detected_class = 'Pequena'
-        elif payload == '10000010':
+        elif payload == b'\x82':  # 10000010
             logger.info('Received UART payload: detected M')
             detected_class = 'Media'
-        elif payload == '10000011':
+        elif payload == b'\x83':  # 10000011
             logger.info('Received UART payload: detected G')
             detected_class = 'Grande'
-        elif payload == '01000000':
+        elif payload == b'\x40':  # 01000000
             logger.info('Received UART payload: emergency state')
             state = 'EMERGENCY'
-        elif payload == '00100000':
+        elif payload == b'\x20':  # 00100000
             logger.info('Received UART payload: system offline')
             status = 'STOP'
         else:
@@ -127,14 +127,14 @@ class UARTSubscriber:
 
                 raw_frame = bytes(rx_frame)
                 logger.debug(f"Raw UART frame received: {raw_frame}")
-                line = raw_frame.decode("utf-8", errors="ignore").strip()
-                logger.debug(f"Decoded UART frame: {line}")
+                # line = raw_frame.decode("utf-8", errors="ignore").strip()
+                #logger.debug(f"Decoded UART frame: {line}")
                 rx_frame.clear()
                 last_rx_time = None
 
-                if not line:
-                    logger.warning("Ignoring empty UART frame after decoding.")
-                    continue
+                # if not line:
+                #     logger.warning("Ignoring empty UART frame after decoding.")
+                #     continue
                 
                 # payload = self._parse_line(line)
                 # if not payload:
@@ -142,12 +142,12 @@ class UARTSubscriber:
                 #     continue
                 # payload.setdefault("source", "uart")
 
-                event_payload = self._convert_UART_payload(line, now)
+                event_payload = self._convert_UART_payload(raw_frame, now)
                 logger.info(f"Transformed UART payload: {event_payload}")
                 if event_payload:
                     await self.aggregator.process_uart_event(event_payload)
                 else:
-                    logger.warning(f"UART line could not be converted to event payload: {line}, skipping.")
+                    logger.warning(f"UART line could not be converted to event payload: {raw_frame}, skipping.")
             except Exception as e:
                 logger.error(f"UART subscriber error while reading/parsing: {e}")
                 await asyncio.sleep(0.5)

--- a/data_aggregator/uart_subscriber.py
+++ b/data_aggregator/uart_subscriber.py
@@ -82,7 +82,7 @@ class UARTSubscriber:
         elif payload == b'\x40':  # 01000000
             logger.info('Received UART payload: emergency state')
             state = 'EMERGENCY'
-        elif payload == b'\x20':  # 00100000
+        elif payload == b'\x00':  # 00000000
             logger.info('Received UART payload: system offline')
             status = 'STOP'
         else:

--- a/data_aggregator/uart_subscriber.py
+++ b/data_aggregator/uart_subscriber.py
@@ -66,10 +66,10 @@ class UARTSubscriber:
         logger.debug(f"Converting UART payload: {payload}")
         detected_class = None
         state = 'NORMAL'
-        status = 'ON'
+        status = None
         if payload == '10000000':
-            logger.warn('Received UART payload: no detections')
-            return None
+            logger.warn('Received UART payload: no detections, system online')
+            status = 'ON'
         elif payload == '10000001':
             logger.info('Received UART payload: detected P')
             detected_class = 'Pequena'
@@ -79,19 +79,19 @@ class UARTSubscriber:
         elif payload == '10000011':
             logger.info('Received UART payload: detected G')
             detected_class = 'Grande'
-        elif payload == '01000000' or payload == '01010000':
+        elif payload == '01000000':
             logger.info('Received UART payload: emergency state')
             state = 'EMERGENCY'
         elif payload == '00100000':
-            logger.info('Received UART payload: system online/offline')
-            status = 'ON/OFF'
+            logger.info('Received UART payload: system offline')
+            status = 'OFF'
         else:
             logger.warning(f"Received UART payload with unknown format: {payload}")
             return None
         return {
             "source": "uart",
             "class": detected_class,
-            "system": state,
+            "state": state,
             "status": status,
             "timestamp": timestamp
         }

--- a/data_aggregator/uart_subscriber.py
+++ b/data_aggregator/uart_subscriber.py
@@ -69,7 +69,7 @@ class UARTSubscriber:
         status = None
         if payload == '10000000':
             logger.warn('Received UART payload: no detections, system online')
-            status = 'ON'
+            status = 'START'
         elif payload == '10000001':
             logger.info('Received UART payload: detected P')
             detected_class = 'Pequena'
@@ -84,7 +84,7 @@ class UARTSubscriber:
             state = 'EMERGENCY'
         elif payload == '00100000':
             logger.info('Received UART payload: system offline')
-            status = 'OFF'
+            status = 'STOP'
         else:
             logger.warning(f"Received UART payload with unknown format: {payload}")
             return None

--- a/main.py
+++ b/main.py
@@ -106,10 +106,12 @@ async def main(
                     publisher.publish(Config.MQTT_TOPIC_CBELT_ACTUATOR, json.dumps({
                         "status": aggregated.uart_data.get("status"),
                         "state": aggregated.uart_data.get("state"),
+                        "timestamp": aggregated.get("timestamp"),
                     }))
                 if aggregated.uart_data.get("state") == "EMERGENCY":
                     publisher.publish(Config.MQTT_TOPIC_CBELT_ACTUATOR, json.dumps({
                         "state": aggregated.uart_data.get("state"),
+                        "timestamp": aggregated.get("timestamp"),
                     }))
             except Exception as e:
                 logger.error(f"Error processing output: {e}")

--- a/main.py
+++ b/main.py
@@ -102,6 +102,15 @@ async def main(
                         "detected_class": aggregated.computed_metrics.get("mcu_class"),
                         "mcu_timestamp": aggregated.computed_metrics.get("mcu_timestamp"),
                     }))
+                if aggregated.uart_data.get("status"):
+                    publisher.publish(Config.MQTT_TOPIC_CBELT_STATUS, json.dumps({
+                        "status": aggregated.uart_data.get("status"),
+                        "state": aggregated.uart_data.get("state"),
+                    }))
+                if aggregated.uart_data.get("state") == "EMERGENCY":
+                    publisher.publish(Config.MQTT_TOPIC_CBELT_STATUS, json.dumps({
+                        "state": aggregated.uart_data.get("state"),
+                    }))
             except Exception as e:
                 logger.error(f"Error processing output: {e}")
 

--- a/main.py
+++ b/main.py
@@ -106,12 +106,12 @@ async def main(
                     publisher.publish(Config.MQTT_TOPIC_CBELT_ACTUATOR, json.dumps({
                         "status": aggregated.uart_data.get("status"),
                         "state": aggregated.uart_data.get("state"),
-                        "timestamp": aggregated.get("timestamp"),
+                        "timestamp": aggregated.timestamp.isoformat(),
                     }))
                 if aggregated.uart_data.get("state") == "EMERGENCY":
                     publisher.publish(Config.MQTT_TOPIC_CBELT_ACTUATOR, json.dumps({
                         "state": aggregated.uart_data.get("state"),
-                        "timestamp": aggregated.get("timestamp"),
+                        "timestamp": aggregated.timestamp.isoformat(),
                     }))
             except Exception as e:
                 logger.error(f"Error processing output: {e}")

--- a/main.py
+++ b/main.py
@@ -103,12 +103,12 @@ async def main(
                         "mcu_timestamp": aggregated.computed_metrics.get("mcu_timestamp"),
                     }))
                 if aggregated.uart_data.get("status"):
-                    publisher.publish(Config.MQTT_TOPIC_CBELT_STATUS, json.dumps({
+                    publisher.publish(Config.MQTT_TOPIC_CBELT_ACTUATOR, json.dumps({
                         "status": aggregated.uart_data.get("status"),
                         "state": aggregated.uart_data.get("state"),
                     }))
                 if aggregated.uart_data.get("state") == "EMERGENCY":
-                    publisher.publish(Config.MQTT_TOPIC_CBELT_STATUS, json.dumps({
+                    publisher.publish(Config.MQTT_TOPIC_CBELT_ACTUATOR, json.dumps({
                         "state": aggregated.uart_data.get("state"),
                     }))
             except Exception as e:


### PR DESCRIPTION
Evento de START a partir do teste de integração direto com MCU

<img width="1836" height="328" alt="image" src="https://github.com/user-attachments/assets/3473d79a-8ca0-40a9-91f2-ce692c0266dd" />

Evento de STOP a partir do teste de integração direto com MCU

<img width="1840" height="408" alt="image" src="https://github.com/user-attachments/assets/befa7398-fd84-417c-a451-e5927f3e5403" />

Não foi possível validar a tempo o fluxo EMERGENCY nos testes de integração
